### PR TITLE
Add support for single parallel LCC

### DIFF
--- a/src/projections/lambert_conformal_conic.rs
+++ b/src/projections/lambert_conformal_conic.rs
@@ -57,12 +57,6 @@ impl LambertConformalConic {
         std_par_2: f64,
         ellps: Ellipsoid,
     ) -> Result<Self, ProjectionError> {
-        // if approx_eq!(f64, std_par_1, std_par_2) {
-        //     return Err(ProjectionError::IncorrectParams(
-        //         "standard parallels cannot be equal",
-        //     ));
-        // }
-
         if !(-180.0..180.0).contains(&ref_lon) {
             return Err(ProjectionError::IncorrectParams(
                 "longitude must be between -180..180",

--- a/src/projections/lambert_conformal_conic.rs
+++ b/src/projections/lambert_conformal_conic.rs
@@ -57,11 +57,11 @@ impl LambertConformalConic {
         std_par_2: f64,
         ellps: Ellipsoid,
     ) -> Result<Self, ProjectionError> {
-        if approx_eq!(f64, std_par_1, std_par_2) {
-            return Err(ProjectionError::IncorrectParams(
-                "standard parallels cannot be equal",
-            ));
-        }
+        // if approx_eq!(f64, std_par_1, std_par_2) {
+        //     return Err(ProjectionError::IncorrectParams(
+        //         "standard parallels cannot be equal",
+        //     ));
+        // }
 
         if !(-180.0..180.0).contains(&ref_lon) {
             return Err(ProjectionError::IncorrectParams(
@@ -98,7 +98,11 @@ impl LambertConformalConic {
         let m_1 = m(phi_1, ellps);
         let m_2 = m(phi_2, ellps);
 
-        let n = n(m_1, m_2, t_1, t_2);
+        let n = if approx_eq!(f64, std_par_1, std_par_2) {
+            phi_1.sin()
+        } else {
+            n(m_1, m_2, t_1, t_2)
+        };
         let big_f = big_f(m_1, n, t_1);
         let rho_0 = rho(big_f, t_0, n, ellps);
 


### PR DESCRIPTION
If one standard parallel is used, , the formula for n is indeterminate but n = sin(phi1)